### PR TITLE
Updated gulp-uglify to version 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gulp-sass": "2.0.4",
     "gulp-selectors": "0.1.8",
     "gulp-sourcemaps": "1.2.8",
-    "gulp-uglify": "1.4.0",
+    "gulp-uglify": "1.4.1",
     "gulp-watch": "4.3.5",
     "gulp-zip": "0.1.2",
     "imagemin-pngquant": "4.2.0",


### PR DESCRIPTION
:rocket:

gulp-uglify just published version 1.4.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 4 commits (ahead by 4, behind by 0).
- [44cc797](https://github.com/terinjokes/gulp-uglify/commit/44cc7977ae28760ddc8eb8ef9bc5be3dea9536b9): chore(changelog): changelog was not commited
- [d82f8d4](https://github.com/terinjokes/gulp-uglify/commit/d82f8d41467fb89e40f2bb15c20ecc908bf40db3): 1.4.1
- [557b4d2](https://github.com/terinjokes/gulp-uglify/commit/557b4d2e09c897961a84476a798f34f36d41f3ac): fix(minifier): detect non-object options argument
- [f8412fd](https://github.com/terinjokes/gulp-uglify/commit/f8412fd3bdbe026da5992577b8329e97d4a5402c): chore(travis-ci): test on Node 4.x

See the [full diff](https://github.com/terinjokes/gulp-uglify/compare/23639f32bad07da9a48ff2fe16d0a547243d702f...44cc7977ae28760ddc8eb8ef9bc5be3dea9536b9).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
