### PR TITLE
Updated gulp-autoprefixer to version 3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "figlet": "1.1.1",
     "gulp": "3.9.0",
     "gulp-angular-templatecache": "1.7.0",
-    "gulp-autoprefixer": "2.3.1",
+    "gulp-autoprefixer": "3.0.2",
     "gulp-babel": "5.2.1",
     "gulp-batch-replace": "0.0.0",
     "gulp-coffee": "2.3.1",


### PR DESCRIPTION
:rocket:

gulp-autoprefixer just published version 3.0.2, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 8 commits (ahead by 8, behind by 0).
- [249cec5](https://github.com/sindresorhus/gulp-autoprefixer/commit/249cec56e591a985216f1a426928900b326933cf): 3.0.2
- [24ed6a4](https://github.com/sindresorhus/gulp-autoprefixer/commit/24ed6a4c78a43d00fdbbae82a130d9436f9174cf): minor tweaks
- [f1ea075](https://github.com/sindresorhus/gulp-autoprefixer/commit/f1ea075c066655ed462b2eb3e21be4693aa9cd21): travis - test on Node.js 4
- [7d4f8b8](https://github.com/sindresorhus/gulp-autoprefixer/commit/7d4f8b86fe612661efebfcd3e1683492f5412d45): 3.0.1
- [88757c5](https://github.com/sindresorhus/gulp-autoprefixer/commit/88757c5d0a75b882a36c87c21270451598ed101a): remove Node.js 0.10 support
- [4b7c43b](https://github.com/sindresorhus/gulp-autoprefixer/commit/4b7c43b3262cf0b71ee820ad339a5e2be3e3e2e8): 3.0.0
- [7bda96e](https://github.com/sindresorhus/gulp-autoprefixer/commit/7bda96e03e07d359c050bea72c3b6f70bd4a849f): add XO
- [a5f34c4](https://github.com/sindresorhus/gulp-autoprefixer/commit/a5f34c41b58c24dbc9335d40f815f1f11410f428): autoprefixer@6.0.0

See the [full diff](https://github.com/sindresorhus/gulp-autoprefixer/compare/02d77661de48890facdf98e1061400264d4f5ef8...249cec56e591a985216f1a426928900b326933cf).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
