### PR TITLE
Updated gulp-rev to version 6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "gulp-plumber": "1.0.1",
     "gulp-rename": "1.2.2",
     "gulp-replace": "0.5.4",
-    "gulp-rev": "5.1.0",
+    "gulp-rev": "6.0.1",
     "gulp-sass": "2.0.4",
     "gulp-selectors": "0.1.8",
     "gulp-sourcemaps": "1.2.8",


### PR DESCRIPTION
:rocket:

gulp-rev just published version 6.0.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 6 commits (ahead by 6, behind by 0).
- [efe4e83](https://github.com/sindresorhus/gulp-rev/commit/efe4e8306766eaa5def495f98996d3bf01da9990): 6.0.1
- [40bb90d](https://github.com/sindresorhus/gulp-rev/commit/40bb90dcad865365c59edfce0a2ad8ee85ea1237): Close #121 PR: Correctly handle a dot in the path. Fixes #88
- [dd394fd](https://github.com/sindresorhus/gulp-rev/commit/dd394fd67262620c11dd41a3f4d912be7d2ccdf2): 6.0.0
- [445aeb3](https://github.com/sindresorhus/gulp-rev/commit/445aeb3ca1268c2c067ebf78b56c11bcb305ffd8): add XO
- [f5a470f](https://github.com/sindresorhus/gulp-rev/commit/f5a470f210b25a56bef3dd2df9afffacb6258a17): cleanup #120
- [f076a90](https://github.com/sindresorhus/gulp-rev/commit/f076a9095d6e1ab861be94770bb69a7015c20a61): Close #120 PR: transformFilename treats the extension as being after the first dot. Fixes #88

See the [full diff](https://github.com/sindresorhus/gulp-rev/compare/0e6fb08f46d71c4f9e12c702fb265f4fca90e10c...efe4e8306766eaa5def495f98996d3bf01da9990).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
