### PR TITLE
Updated gulp-sourcemaps to version 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "gulp-rev": "5.1.0",
     "gulp-sass": "2.0.4",
     "gulp-selectors": "0.1.8",
-    "gulp-sourcemaps": "1.2.8",
+    "gulp-sourcemaps": "1.6.0",
     "gulp-uglify": "1.4.0",
     "gulp-watch": "4.3.5",
     "gulp-zip": "0.1.2",


### PR DESCRIPTION
:rocket:

gulp-sourcemaps just published version 1.6.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 39 commits (ahead by 39, behind by 0).
- [cddce0d](https://github.com/floridoo/gulp-sourcemaps/commit/cddce0d57e462b89b7d7f7c1d1864ad2784d17ef): v1.6.0
- [b7037d7](https://github.com/floridoo/gulp-sourcemaps/commit/b7037d7cb579c555f9b5182d15fb0b5c0a17b59b): write newline after sourceMappingURL comment
- [8c2aff8](https://github.com/floridoo/gulp-sourcemaps/commit/8c2aff8d4fd38a41709281a70ff670150e19266d): Add `sourceMappingURL` option
- [ab6f2f5](https://github.com/floridoo/gulp-sourcemaps/commit/ab6f2f5ea5ddf9587b5be840503a413d78fbd04d): Codestyle: use camel case
- [ad99c96](https://github.com/floridoo/gulp-sourcemaps/commit/ad99c9637187035ea59ad006d2d0794e1b198710): Pass through if source map already exists
- [8b90295](https://github.com/floridoo/gulp-sourcemaps/commit/8b90295b411352bb4d25820e23cfbf4161bd580c): Keep empty string sourceRoot
- [22f4ff5](https://github.com/floridoo/gulp-sourcemaps/commit/22f4ff548208352177fb6fc88e6c78787c5935af): Merge pull request #151 from jordansexton/webpack-url-regex
- [8eb63ad](https://github.com/floridoo/gulp-sourcemaps/commit/8eb63ad65548e06b33c26f422aba487cdb4097c8): Merge pull request #148 from AssassinsMod/master
- [a0c236a](https://github.com/floridoo/gulp-sourcemaps/commit/a0c236ac1c4160be2f6feffab3a36ce5d239e3c3): Added sourcemap's file `stat` property to improve compatibility with other modules.
- [712e89f](https://github.com/floridoo/gulp-sourcemaps/commit/712e89fd7f74dcd9876257511b6e18b6a3cdf376): Fix cover command
- [8f0acf8](https://github.com/floridoo/gulp-sourcemaps/commit/8f0acf884d0fcf75d429c933a651ad15140a08de): Allow to unset the sourceRoot explicitly by setting it to null
- [7ffa57e](https://github.com/floridoo/gulp-sourcemaps/commit/7ffa57e7d4123b9fd471170c9c3820cf131b5ee3): Merge pull request #84 from gpndata:master
- [696e176](https://github.com/floridoo/gulp-sourcemaps/commit/696e17612f63b0b8eb96f8dd41eaeae53ee5a5ff): path in sourceMappingURL should be shortest possible
- [958f86c](https://github.com/floridoo/gulp-sourcemaps/commit/958f86ccf0035e55234dc35668cec1654a05a860): Update dependencies
- [c240ac2](https://github.com/floridoo/gulp-sourcemaps/commit/c240ac2cb1bc1d05819ab83775039eb114436a61): Support webpack:// relative URLs

There are 39 commits in total. See the [full diff](https://github.com/floridoo/gulp-sourcemaps/compare/2b6f467b96f3eede5bfd7b5cf7d5048807a3caca...cddce0d57e462b89b7d7f7c1d1864ad2784d17ef).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
