### PR TITLE
Updated browser-sync to version 2.9.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gtb",
   "version": "0.9.2",
   "dependencies": {
-    "browser-sync": "2.9.7",
+    "browser-sync": "2.9.9",
     "chalk": "1.1.1",
     "connect-history-api-fallback": "1.1.0",
     "deferred": "0.7.3",


### PR DESCRIPTION
:rocket:

browser-sync just published version 2.9.9, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 7 commits (ahead by 7, behind by 0).
- [fe716bb](https://github.com/BrowserSync/browser-sync/commit/fe716bb382172df638bbea74aea6e6f988e80515): 2.9.9
- [01056c5](https://github.com/BrowserSync/browser-sync/commit/01056c5b8f9a4f9aaa644b1c9960094e98d2d443): deps: bump browser-sync-client@2.3.2 for fixes relating to #449
- [12095f3](https://github.com/BrowserSync/browser-sync/commit/12095f376279b82214da87231efc9d7943f1719b): deps: pin meow@3.3 until https://github.com/sindresorhus/meow/issues/11 is resolved
- [1d86f1a](https://github.com/BrowserSync/browser-sync/commit/1d86f1a8bae3d9228f732d3022644c2ebe521186): 2.9.8
- [f0cb7d0](https://github.com/BrowserSync/browser-sync/commit/f0cb7d006921ead86a7d4c5c7c649578033ffc37): fix(browser-option): use updated  api fixes #849
- [3229086](https://github.com/BrowserSync/browser-sync/commit/322908699b8a01bb72f914155bbf5e7605ab2341): Merge pull request #846 from schmod/patch-1
- [445a7ff](https://github.com/BrowserSync/browser-sync/commit/445a7ffadd701971c15b71e42ee84ff3fce667b5): Fix broken links in CONTRIBUTING.md

See the [full diff](https://github.com/BrowserSync/browser-sync/compare/33103c8ebb747d6c33e61e2b43a230280ddedb73...fe716bb382172df638bbea74aea6e6f988e80515).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
